### PR TITLE
Modernize the Perl code a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+Originally created by Paul St...ington for the Teensy 3.5/3.6 kickstarter
+Updated to handle unicode slightly better by Ryan Voots
+
+To install the needed perl libraries use the (cpanminus)[https://github.com/miyagawa/cpanminus] client
+
+	cpanm --installdeps .
+
+To run the program you'll need the CSV files from kickstarter broken out by reward levels.  
+Each .txt file contains a list of the products for each level and is used for generating the invoice/reference numbers.
+
+	./kickstarter2mailinnovations.pl test.csv a.txt
+
+See run.sh for a little more information about automating this process.
+	

--- a/countries.pl
+++ b/countries.pl
@@ -1,29 +1,32 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # print a quick summary of the number of rewards to each country
+use strict;
+use warnings;
 
-use Text::CSV;   # sudo apt-get install libtext-csv-perl
+use Text::CSV; # sudo apt-get install libtext-csv-perl
 
-my $csv = Text::CSV->new ({ binary => 1 });
+my $csv = Text::CSV->new({ binary => 1 });
 
-foreach $file (@ARGV) {
-	print "File $file\n";
-	open $fh, "<", $file or die "$!";
-		$header = $csv->getline($fh);
-		while ($row = $csv->getline($fh)) {
-			$country = $row->[21];
-			print "Country: $country\n";
-			if ($country) {
-				$list{$country}++;
-			}
-		}
-	close $fh;
+my %list;
+
+for my $file (@ARGV) {
+    print "File $file\n";
+    open(my $fh, "<", $file) or die "$!";
+    my $header = $csv->getline($fh);
+
+    while (my $row = $csv->getline($fh)) {
+        my $country = $row->[21];
+
+        next unless $country;
+
+        print "Country: $country\n";
+        $list{$country}++;
+    }
 }
 
-foreach $country (sort keys(%list)) {
-	printf " %4d: ", $list{$country};
-	print "$country\n";
-
-
+for my $country (sort keys(%list)) {
+    printf " %4d: ", $list{$country};
+    print "$country\n";
 }
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,2 @@
+requires 'XML::LibXML' => 0;
+requires 'Text::CSV::Encoded' => 0;

--- a/kickstarter2mailinnovations.pl
+++ b/kickstarter2mailinnovations.pl
@@ -1,7 +1,12 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # convert a Kickstarter CSV file to many UPS Worldship XML files
 # for use with the "XML Auto Import" feature.
+
+use warnings;
+use strict;
+use Encode;
+use Data::Dumper;
 
 use Text::CSV;   # sudo apt-get install libtext-csv-perl
 use XML::LibXML; # sudo apt-get install libxml-libxml-perl
@@ -9,214 +14,214 @@ use XML::LibXML; # sudo apt-get install libxml-libxml-perl
 my $csv = Text::CSV->new ({ binary => 1 });
 
 (exists $ARGV[0] && $ARGV[0] =~ /\.csv$/ &&
- exists $ARGV[1] && $ARGV[1] =~ /^([a-zA-Z])\.txt$/) 
-	or die "usage: kickstarter2mailinnovations.pl file.cvs N.txt\n";
-$reward = uc($1);
+ exists $ARGV[1] && $ARGV[1] =~ /^([a-zA-Z])\.txt$/)
+  or die "usage: kickstarter2mailinnovations.pl file.csv N.txt\n";
+my $reward = uc($1);
 -r $ARGV[0] or die "Unable to read \"$ARGV[0]\"\n";
 -r $ARGV[1] or die "Unable to read \"$ARGV[1]\"\n";
 
+my @items;
 
-open $fh, "<", $ARGV[1] or die "$!";
-$numitems = 0;
-$total = 0;
-while (<$fh>) {
-	#print "Item: $_\n";
-	($qty[$numitems], $item[$numitems], $price[$numitems]) = split;
-	$total += $price[$numitems] * $qty[$numitems];
-	$numitems++;
-	#@list = split;
-	#print "Item: $list[0] ", join(", ", @list), "\n";
+open(my $txtfh, "<", $ARGV[1]) or die "$!";
+my $numitems = 0;
+my $total = 0;
+while (my $line = <$txtfh>) {
+  #print "Item: $_\n";
+
+  my ($qty, $name, $price) = split ' ', $line;
+  push @items, {qty => $qty, name => $name, price => $price};
+  $total += $price * $qty;
+  $numitems++;
+  #@list = split;
+  #print "Item: $list[0] ", join(", ", @list), "\n";
 }
-close $fh;
-
+close($txtfh);
 
 print "total:  $total\n";
 print "Reward: $reward\n";
 print "File: $ARGV[0]\n";
 
-open $fh, "<", $ARGV[0] or die "$!";
+open(my $csvfh, "<", $ARGV[0]) or die "$!";
 #open $fh, "<:encoding(utf8)", $ARGV[0] or die "$!";
-open $fref, ">>", "allrefnums.txt" or die "$!";
+open(my $fref, ">>", "allrefnums.txt") or die "$!";
 
-$header = $csv->getline($fh);
-#print  $header->[24], "\n";
+my $header = $csv->getline($csvfh);
 
-while ($row = $csv->getline($fh)) {
-	$toolong = 0;
-	$name = $row->[15];
-	$addr1 = $row->[16];
-	$addr2 = $row->[17];
-	$city = $row->[18];
-	$state = $row->[19];
-	$postalcode = $row->[20];
-	$country = $row->[21];
-	$phone = $row->[23];
-	next unless $country;
+while (my $row = $csv->getline($csvfh)) {
+  my $specialchars = 0;
+  my $toolong = 0;
+  my $name = $row->[15];
+  my $addr1 = $row->[16];
+  my $addr2 = $row->[17];
+  my $city = $row->[18];
+  my $state = $row->[19];
+  my $postalcode = $row->[20];
+  my $country = $row->[21];
+  my $phone = $row->[23];
+#  print Dumper({name => $name, addr1 => $addr1, addr2 => $addr2, city => $city, state => $state, postalcode => $postalcode, country =>$country, phone => $phone});
+  next unless $country;
 
-	$refnum = $reward . sprintf("%04d", $row->[0]);
-	print $fref "$refnum\n";
+  my $refnum = $reward . sprintf("%04d", $row->[0]);
+  print $fref "$refnum\n";
 
-	next if $country eq "United States";
-	if ($country eq "Brunei Darussalam") {
-		$country = "Brunei";
-	} elsif ($country eq "China") {
-		$country = "China, People's Republic of";
-	} elsif ($country eq "Korea, Republic of") {
-		$country = "Korea, South";
-	} elsif ($country eq "Russian Federation") {
-		$country = "Russia";
-	}
+  next if $country eq "United States";
+  if ($country eq "Brunei Darussalam") {
+    $country = "Brunei";
+  } elsif ($country eq "China") {
+    $country = "China, People's Republic of";
+  } elsif ($country eq "Korea, Republic of") {
+    $country = "Korea, South";
+  } elsif ($country eq "Russian Federation") {
+    $country = "Russia";
+  }
 
-	if (length($name) > 35 || length($addr1) > 35 || length($addr2) > 35
-	  || length($city) > 30 || length($postalcode) > 35 || length($phone) > 15) {
-		$toolong = 1;
-	}
+  if (length($name) > 35 || length($addr1) > 35 || length($addr2) > 35
+    || length($city) > 30 || length($postalcode) > 35 || length($phone) > 15) {
+    $toolong = 1;
+  }
 
-	$all = $name . $addr1 . $addr2 . $city . $state . $postalcode . $country . $phone;
-	if ($all =~ /[\x{100}-\x{FFFF}]/) {
-		$specialchars = 2;
-	} elsif ($all =~ /[\x{80}-\x{FF}]/) {
-		$specialchars = 1;
-	} else {
-		$specialchars = 0;
-	}
+  my $all = $name . $addr1 . $addr2 . $city . $state . $postalcode . $country . $phone;
+  if ($all =~ /[\x{100}-\x{FFFF}]/) {
+    $specialchars = 2;
+  } elsif ($all =~ /[\x{80}-\x{FF}]/) {
+    $specialchars = 1;
+  } else {
+    $specialchars = 0;
+  }
 
-	print "Ref #:   ", $refnum, ",  ";
-	print "Backer:  ", $row->[2], "\n";
+  print "Ref #:   ", $refnum, ",  ";
+  print "Backer:  ", $row->[2], "\n";
 
-	$doc = XML::LibXML::Document->new("1.0", "UTF-8");
+  my $doc = XML::LibXML::Document->new("1.0", "UTF-8");
 
-	$OpenShipments = $doc->createElement("OpenShipments");
-	$doc->setDocumentElement($OpenShipments);
-	$OpenShipments->setAttribute("xmlns" => "x-schema:OpenShipments.xdr");
+  my $OpenShipments = $doc->createElement("OpenShipments");
+  $doc->setDocumentElement($OpenShipments);
+  $OpenShipments->setAttribute("xmlns" => "x-schema:OpenShipments.xdr");
 
-	$OpenShipment = $doc->createElement("OpenShipment");
-	$OpenShipments->appendChild($OpenShipment);
-	$OpenShipment->setAttribute("ShipmentOption" => "SP");
-	$OpenShipment->setAttribute("ProcessStatus" => "");
+  my $OpenShipment = $doc->createElement("OpenShipment");
+  $OpenShipments->appendChild($OpenShipment);
+  $OpenShipment->setAttribute("ShipmentOption" => "SP");
+  $OpenShipment->setAttribute("ProcessStatus" => "");
 
-	$ShipTo = $doc->createElement("ShipTo");
-	$OpenShipment->appendChild($ShipTo);
+  my $ShipTo = $doc->createElement("ShipTo");
+  $OpenShipment->appendChild($ShipTo);
 
-	$CompanyOrName = $doc->createElement("CompanyOrName");
-	$CompanyOrName->appendTextNode($name);
-	$ShipTo->appendChild($CompanyOrName);
-	$Attention = $doc->createElement("Attention");
-	$Attention->appendTextNode($name);
-	$ShipTo->appendChild($Attention);
-	$Address1 = $doc->createElement("Address1");
-	$Address1->appendTextNode($addr1);
-	$ShipTo->appendChild($Address1);
-	if ($addr2) {
-		$Address2 = $doc->createElement("Address2");
-		$Address2->appendTextNode($addr2);
-		$ShipTo->appendChild($Address2);
-	}
-	$CountryTerritory = $doc->createElement("CountryTerritory");
-	$CountryTerritory->appendTextNode($country);
-	$ShipTo->appendChild($CountryTerritory);
-	$PostalCode = $doc->createElement("PostalCode");
-	$PostalCode->appendTextNode($postalcode);
-	$ShipTo->appendChild($PostalCode);
-	$CityOrTown = $doc->createElement("CityOrTown");
-	$CityOrTown->appendTextNode($city);
-	$ShipTo->appendChild($CityOrTown);
-	$StateProvinceCounty = $doc->createElement("StateProvinceCounty");
-	$StateProvinceCounty->appendTextNode($state);
-	$ShipTo->appendChild($StateProvinceCounty);
-	$Telephone = $doc->createElement("Telephone");
-	$Telephone->appendTextNode($phone);
-	$ShipTo->appendChild($Telephone);
+  my $CompanyOrName = $doc->createElement("CompanyOrName");
+  $CompanyOrName->appendTextNode($name);
+  $ShipTo->appendChild($CompanyOrName);
+  my $Attention = $doc->createElement("Attention");
+  $Attention->appendTextNode($name);
+  $ShipTo->appendChild($Attention);
+  my $Address1 = $doc->createElement("Address1");
+  $Address1->appendTextNode($addr1);
+  $ShipTo->appendChild($Address1);
+  if ($addr2) {
+    my $Address2 = $doc->createElement("Address2");
+    $Address2->appendTextNode($addr2);
+    $ShipTo->appendChild($Address2);
+  }
+  my $CountryTerritory = $doc->createElement("CountryTerritory");
+  $CountryTerritory->appendTextNode($country);
+  $ShipTo->appendChild($CountryTerritory);
+  my $PostalCode = $doc->createElement("PostalCode");
+  $PostalCode->appendTextNode($postalcode);
+  $ShipTo->appendChild($PostalCode);
+  my $CityOrTown = $doc->createElement("CityOrTown");
+  $CityOrTown->appendTextNode($city);
+  $ShipTo->appendChild($CityOrTown);
+  my $StateProvinceCounty = $doc->createElement("StateProvinceCounty");
+  $StateProvinceCounty->appendTextNode($state);
+  $ShipTo->appendChild($StateProvinceCounty);
+  my $Telephone = $doc->createElement("Telephone");
+  $Telephone->appendTextNode($phone);
+  $ShipTo->appendChild($Telephone);
 
-	$ShipmentInformation = $doc->createElement("ShipmentInformation");
-	$OpenShipment->appendChild($ShipmentInformation);
-	$ServiceType = $doc->createElement("ServiceType");
-	$ServiceType->appendTextNode("MIP");
-	$ShipmentInformation->appendChild($ServiceType);
-	$PackageType = $doc->createElement("PackageType");
-	$PackageType->appendTextNode("Parcels");
-	$ShipmentInformation->appendChild($PackageType);
-	$NumberOfPackages = $doc->createElement("NumberOfPackages");
-	$NumberOfPackages->appendTextNode("1");
-	$ShipmentInformation->appendChild($NumberOfPackages);
-	$ShipmentActualWeight = $doc->createElement("ShipmentActualWeight");
-	$ShipmentActualWeight->appendTextNode("0.1");
-	$ShipmentInformation->appendChild($ShipmentActualWeight);
-	$DescriptionOfGoods = $doc->createElement("DescriptionOfGoods");
-	$DescriptionOfGoods->appendTextNode("Electronic Parts");
-	$ShipmentInformation->appendChild($DescriptionOfGoods);
-	$Reference1 = $doc->createElement("Reference1");
-	$Reference1->appendTextNode($refnum);
-	$ShipmentInformation->appendChild($Reference1);
-	$Reference2 = $doc->createElement("Reference2");
-	$Reference2->appendTextNode("KS");
-	$ShipmentInformation->appendChild($Reference2);
-	$BillTransportationTo = $doc->createElement("BillTransportationTo");
-	$BillTransportationTo->appendTextNode("Shipper");
-	$ShipmentInformation->appendChild($BillTransportationTo);
-	$BillDutyTaxTo = $doc->createElement("BillDutyTaxTo");
-	$BillDutyTaxTo->appendTextNode("Receiver");
-	$ShipmentInformation->appendChild($BillDutyTaxTo);
+  my $ShipmentInformation = $doc->createElement("ShipmentInformation");
+  $OpenShipment->appendChild($ShipmentInformation);
+  my $ServiceType = $doc->createElement("ServiceType");
+  $ServiceType->appendTextNode("MIP");
+  $ShipmentInformation->appendChild($ServiceType);
+  my $PackageType = $doc->createElement("PackageType");
+  $PackageType->appendTextNode("Parcels");
+  $ShipmentInformation->appendChild($PackageType);
+  my $NumberOfPackages = $doc->createElement("NumberOfPackages");
+  $NumberOfPackages->appendTextNode("1");
+  $ShipmentInformation->appendChild($NumberOfPackages);
+  my $ShipmentActualWeight = $doc->createElement("ShipmentActualWeight");
+  $ShipmentActualWeight->appendTextNode("0.1");
+  $ShipmentInformation->appendChild($ShipmentActualWeight);
+  my $DescriptionOfGoods = $doc->createElement("DescriptionOfGoods");
+  $DescriptionOfGoods->appendTextNode("Electronic Parts");
+  $ShipmentInformation->appendChild($DescriptionOfGoods);
+  my $Reference1 = $doc->createElement("Reference1");
+  $Reference1->appendTextNode($refnum);
+  $ShipmentInformation->appendChild($Reference1);
+  my $Reference2 = $doc->createElement("Reference2");
+  $Reference2->appendTextNode("KS");
+  $ShipmentInformation->appendChild($Reference2);
+  my $BillTransportationTo = $doc->createElement("BillTransportationTo");
+  $BillTransportationTo->appendTextNode("Shipper");
+  $ShipmentInformation->appendChild($BillTransportationTo);
+  my $BillDutyTaxTo = $doc->createElement("BillDutyTaxTo");
+  $BillDutyTaxTo->appendTextNode("Receiver");
+  $ShipmentInformation->appendChild($BillDutyTaxTo);
 
-	$InternationalDocumentation = $doc->createElement("InternationalDocumentation");
-	$OpenShipment->appendChild($InternationalDocumentation);
-	$CustomsValueTotal = $doc->createElement("CustomsValueTotal");
-	$CustomsValueTotal->appendTextNode(sprintf("%.2f", $total));
-	$InternationalDocumentation->appendChild($CustomsValueTotal);
-	$CustomsValueCurrencyCode = $doc->createElement("CustomsValueCurrencyCode");
-	$CustomsValueCurrencyCode->appendTextNode("USD");
-	$InternationalDocumentation->appendChild($CustomsValueCurrencyCode);
-	$InvoiceCurrencyCode = $doc->createElement("InvoiceCurrencyCode");
-	$InvoiceCurrencyCode->appendTextNode("US");
-	$InternationalDocumentation->appendChild($InvoiceCurrencyCode);
-	$CN22GoodsType = $doc->createElement("CN22GoodsType");
-	$CN22GoodsType->appendTextNode("4");
-	$InternationalDocumentation->appendChild($CN22GoodsType);
-	$CN22GoodsTypeOtherDescription = $doc->createElement("CN22GoodsTypeOtherDescription");
-	$CN22GoodsTypeOtherDescription->appendTextNode("Electronic Parts");
-	$InternationalDocumentation->appendChild($CN22GoodsTypeOtherDescription);
+  my $InternationalDocumentation = $doc->createElement("InternationalDocumentation");
+  $OpenShipment->appendChild($InternationalDocumentation);
+  my $CustomsValueTotal = $doc->createElement("CustomsValueTotal");
+  $CustomsValueTotal->appendTextNode(sprintf("%.2f", $total));
+  $InternationalDocumentation->appendChild($CustomsValueTotal);
+  my $CustomsValueCurrencyCode = $doc->createElement("CustomsValueCurrencyCode");
+  $CustomsValueCurrencyCode->appendTextNode("USD");
+  $InternationalDocumentation->appendChild($CustomsValueCurrencyCode);
+  my $InvoiceCurrencyCode = $doc->createElement("InvoiceCurrencyCode");
+  $InvoiceCurrencyCode->appendTextNode("US");
+  $InternationalDocumentation->appendChild($InvoiceCurrencyCode);
+  my $CN22GoodsType = $doc->createElement("CN22GoodsType");
+  $CN22GoodsType->appendTextNode("4");
+  $InternationalDocumentation->appendChild($CN22GoodsType);
+  my $CN22GoodsTypeOtherDescription = $doc->createElement("CN22GoodsTypeOtherDescription");
+  $CN22GoodsTypeOtherDescription->appendTextNode("Electronic Parts");
+  $InternationalDocumentation->appendChild($CN22GoodsTypeOtherDescription);
 
-	for ($i=0; $i < $numitems; $i++) {
-		$Goods = $doc->createElement("Goods");
-		$OpenShipment->appendChild($Goods);
-		$PartNumber = $doc->createElement("PartNumber");
-		$PartNumber->appendTextNode($item[$i]);
-		$Goods->appendChild($PartNumber);
-		$DescriptionOfGood = $doc->createElement("DescriptionOfGood");
-		$DescriptionOfGood->appendTextNode("Electronic Part: " . $item[$i]);
-		$Goods->appendChild($DescriptionOfGood);
-		$TariffCode = $doc->createElement("Inv-NAFTA-TariffCode");
-		$TariffCode->appendTextNode("854231");
-		$Goods->appendChild($TariffCode);
-		$Origin = $doc->createElement("Inv-NAFTA-CO-CountryTerritoryOfOrigin");
-		$Origin->appendTextNode("US");
-		$Goods->appendChild($Origin);
-		$InvoiceUnits = $doc->createElement("InvoiceUnits");
-		$InvoiceUnits->appendTextNode($qty[$i]);
-		$Goods->appendChild($InvoiceUnits);
-		$InvoiceUnitOfMeasure = $doc->createElement("InvoiceUnitOfMeasure");
-		$InvoiceUnitOfMeasure->appendTextNode("EA");
-		$Goods->appendChild($InvoiceUnitOfMeasure);
-		$UnitPrice = $doc->createElement("Invoice-SED-UnitPrice");
-		$UnitPrice->appendTextNode(sprintf("%.2f", $price[$i]));
-		$Goods->appendChild($UnitPrice);
-		$InvoiceCurrencyCode = $doc->createElement("InvoiceCurrencyCode");
-		$InvoiceCurrencyCode->appendTextNode("US");
-		$Goods->appendChild($InvoiceCurrencyCode);
-	}
-	$filename = $refnum;
- 	if ($specialchars > 1) {
-		$filename .= "_specialchars"
-	} elsif ($specialchars == 1) {
-		$filename .= "_latinchars"
-	}
- 	if ($toolong) {
-		$filename .= "_long"
-	}
-	$doc->toFile($filename . ".xml", 2);
-	#print $doc->toString(2);
-	#exit;
+  for my $item (@items) {
+    my $Goods = $doc->createElement("Goods");
+    $OpenShipment->appendChild($Goods);
+    my $PartNumber = $doc->createElement("PartNumber");
+    $PartNumber->appendTextNode($item->{name});
+    $Goods->appendChild($PartNumber);
+    my $DescriptionOfGood = $doc->createElement("DescriptionOfGood");
+    $DescriptionOfGood->appendTextNode("Electronic Part: " . $item->{name});
+    $Goods->appendChild($DescriptionOfGood);
+    my $TariffCode = $doc->createElement("Inv-NAFTA-TariffCode");
+    $TariffCode->appendTextNode("854231");
+    $Goods->appendChild($TariffCode);
+    my $Origin = $doc->createElement("Inv-NAFTA-CO-CountryTerritoryOfOrigin");
+    $Origin->appendTextNode("US");
+    $Goods->appendChild($Origin);
+    my $InvoiceUnits = $doc->createElement("InvoiceUnits");
+    $InvoiceUnits->appendTextNode($item->{qty});
+    $Goods->appendChild($InvoiceUnits);
+    my $InvoiceUnitOfMeasure = $doc->createElement("InvoiceUnitOfMeasure");
+    $InvoiceUnitOfMeasure->appendTextNode("EA");
+    $Goods->appendChild($InvoiceUnitOfMeasure);
+    my $UnitPrice = $doc->createElement("Invoice-SED-UnitPrice");
+    $UnitPrice->appendTextNode(sprintf("%.2f", $item->{price}));
+    $Goods->appendChild($UnitPrice);
+    my $InvoiceCurrencyCode = $doc->createElement("InvoiceCurrencyCode");
+    $InvoiceCurrencyCode->appendTextNode("US");
+    $Goods->appendChild($InvoiceCurrencyCode);
+  }
+  my $filename = $refnum;
+  if ($specialchars > 1) {
+    $filename .= "_specialchars"
+  } elsif ($specialchars == 1) {
+    $filename .= "_latinchars"
+  }
+  if ($toolong) {
+    $filename .= "_long"
+  }
+  $doc->toFile($filename . ".xml", 2);
+  #print $doc->toString(2);
+  #exit;
 }
-
-close $fh;
-close $fref;

--- a/kickstarter2mailinnovations.pl
+++ b/kickstarter2mailinnovations.pl
@@ -94,14 +94,15 @@ while (my $row = $csv->getline($csvfh)) {
     elsif ($all =~ /[\x{80}-\x{FF}]/) {
         $specialchars = 1;
     }
-    else {
-        $specialchars = 0;
-    }
 
     print "Ref #:   ", $refnum, ",  ";
     print "Backer:  ", $row->[2], "\n";
 
     my $doc = XML::LibXML::Document->new("1.0", "UTF-8");
+
+    # TODO I'm fairly certain this XML generation code could be cleaned up further
+    # with some gratuitous use of method chaining and fewer variables but I'm not going
+    # to even attempt it since I don't have a way to test the output properly. --rvoots
 
     my $OpenShipments = $doc->createElement("OpenShipments");
     $doc->setDocumentElement($OpenShipments);
@@ -233,6 +234,4 @@ while (my $row = $csv->getline($csvfh)) {
         $filename .= "_long";
     }
     $doc->toFile($filename . ".xml", 2);
-    #print $doc->toString(2);
-    #exit;
 }

--- a/kickstarter2mailinnovations.pl
+++ b/kickstarter2mailinnovations.pl
@@ -27,7 +27,7 @@ my $total    = 0;
 while (my $line = <$txtfh>) {
     #print "Item: $_\n";
 
-    my ($qty, $name, $price) = split ' ', $line;
+    my ($qty, $name, $price) = split(' ', $line);
     push @items, { qty => $qty, name => $name, price => $price };
     $total += $price * $qty;
     $numitems++;

--- a/kickstarter2mailinnovations.pl
+++ b/kickstarter2mailinnovations.pl
@@ -8,14 +8,13 @@ use strict;
 use Encode;
 use Data::Dumper;
 
-use Text::CSV;   # sudo apt-get install libtext-csv-perl
+use Text::CSV; # sudo apt-get install libtext-csv-perl
 use XML::LibXML; # sudo apt-get install libxml-libxml-perl
 
-my $csv = Text::CSV->new ({ binary => 1 });
+my $csv = Text::CSV->new({ binary => 1 });
 
-(exists $ARGV[0] && $ARGV[0] =~ /\.csv$/ &&
- exists $ARGV[1] && $ARGV[1] =~ /^([a-zA-Z])\.txt$/)
-  or die "usage: kickstarter2mailinnovations.pl file.csv N.txt\n";
+(exists $ARGV[0] && $ARGV[0] =~ /\.csv$/ && exists $ARGV[1] && $ARGV[1] =~ /^([a-zA-Z])\.txt$/)
+    or die "usage: kickstarter2mailinnovations.pl file.csv N.txt\n";
 my $reward = uc($1);
 -r $ARGV[0] or die "Unable to read \"$ARGV[0]\"\n";
 -r $ARGV[1] or die "Unable to read \"$ARGV[1]\"\n";
@@ -24,16 +23,16 @@ my @items;
 
 open(my $txtfh, "<", $ARGV[1]) or die "$!";
 my $numitems = 0;
-my $total = 0;
+my $total    = 0;
 while (my $line = <$txtfh>) {
-  #print "Item: $_\n";
+    #print "Item: $_\n";
 
-  my ($qty, $name, $price) = split ' ', $line;
-  push @items, {qty => $qty, name => $name, price => $price};
-  $total += $price * $qty;
-  $numitems++;
-  #@list = split;
-  #print "Item: $list[0] ", join(", ", @list), "\n";
+    my ($qty, $name, $price) = split ' ', $line;
+    push @items, { qty => $qty, name => $name, price => $price };
+    $total += $price * $qty;
+    $numitems++;
+    #@list = split;
+    #print "Item: $list[0] ", join(", ", @list), "\n";
 }
 close($txtfh);
 
@@ -48,180 +47,192 @@ open(my $fref, ">>", "allrefnums.txt") or die "$!";
 my $header = $csv->getline($csvfh);
 
 while (my $row = $csv->getline($csvfh)) {
-  my $specialchars = 0;
-  my $toolong = 0;
-  my $name = $row->[15];
-  my $addr1 = $row->[16];
-  my $addr2 = $row->[17];
-  my $city = $row->[18];
-  my $state = $row->[19];
-  my $postalcode = $row->[20];
-  my $country = $row->[21];
-  my $phone = $row->[23];
+    my $specialchars = 0;
+    my $toolong      = 0;
+    my $name         = $row->[15];
+    my $addr1        = $row->[16];
+    my $addr2        = $row->[17];
+    my $city         = $row->[18];
+    my $state        = $row->[19];
+    my $postalcode   = $row->[20];
+    my $country      = $row->[21];
+    my $phone        = $row->[23];
 #  print Dumper({name => $name, addr1 => $addr1, addr2 => $addr2, city => $city, state => $state, postalcode => $postalcode, country =>$country, phone => $phone});
-  next unless $country;
+    next unless $country;
 
-  my $refnum = $reward . sprintf("%04d", $row->[0]);
-  print $fref "$refnum\n";
+    my $refnum = $reward . sprintf("%04d", $row->[0]);
+    print $fref "$refnum\n";
 
-  next if $country eq "United States";
-  if ($country eq "Brunei Darussalam") {
-    $country = "Brunei";
-  } elsif ($country eq "China") {
-    $country = "China, People's Republic of";
-  } elsif ($country eq "Korea, Republic of") {
-    $country = "Korea, South";
-  } elsif ($country eq "Russian Federation") {
-    $country = "Russia";
-  }
+    next if $country eq "United States";
+    if ($country eq "Brunei Darussalam") {
+        $country = "Brunei";
+    }
+    elsif ($country eq "China") {
+        $country = "China, People's Republic of";
+    }
+    elsif ($country eq "Korea, Republic of") {
+        $country = "Korea, South";
+    }
+    elsif ($country eq "Russian Federation") {
+        $country = "Russia";
+    }
 
-  if (length($name) > 35 || length($addr1) > 35 || length($addr2) > 35
-    || length($city) > 30 || length($postalcode) > 35 || length($phone) > 15) {
-    $toolong = 1;
-  }
+    if (   length($name) > 35
+        || length($addr1) > 35
+        || length($addr2) > 35
+        || length($city) > 30
+        || length($postalcode) > 35
+        || length($phone) > 15)
+    {
+        $toolong = 1;
+    }
 
-  my $all = $name . $addr1 . $addr2 . $city . $state . $postalcode . $country . $phone;
-  if ($all =~ /[\x{100}-\x{FFFF}]/) {
-    $specialchars = 2;
-  } elsif ($all =~ /[\x{80}-\x{FF}]/) {
-    $specialchars = 1;
-  } else {
-    $specialchars = 0;
-  }
+    my $all = $name . $addr1 . $addr2 . $city . $state . $postalcode . $country . $phone;
+    if ($all =~ /[\x{100}-\x{FFFF}]/) {
+        $specialchars = 2;
+    }
+    elsif ($all =~ /[\x{80}-\x{FF}]/) {
+        $specialchars = 1;
+    }
+    else {
+        $specialchars = 0;
+    }
 
-  print "Ref #:   ", $refnum, ",  ";
-  print "Backer:  ", $row->[2], "\n";
+    print "Ref #:   ", $refnum, ",  ";
+    print "Backer:  ", $row->[2], "\n";
 
-  my $doc = XML::LibXML::Document->new("1.0", "UTF-8");
+    my $doc = XML::LibXML::Document->new("1.0", "UTF-8");
 
-  my $OpenShipments = $doc->createElement("OpenShipments");
-  $doc->setDocumentElement($OpenShipments);
-  $OpenShipments->setAttribute("xmlns" => "x-schema:OpenShipments.xdr");
+    my $OpenShipments = $doc->createElement("OpenShipments");
+    $doc->setDocumentElement($OpenShipments);
+    $OpenShipments->setAttribute("xmlns" => "x-schema:OpenShipments.xdr");
 
-  my $OpenShipment = $doc->createElement("OpenShipment");
-  $OpenShipments->appendChild($OpenShipment);
-  $OpenShipment->setAttribute("ShipmentOption" => "SP");
-  $OpenShipment->setAttribute("ProcessStatus" => "");
+    my $OpenShipment = $doc->createElement("OpenShipment");
+    $OpenShipments->appendChild($OpenShipment);
+    $OpenShipment->setAttribute("ShipmentOption" => "SP");
+    $OpenShipment->setAttribute("ProcessStatus"  => "");
 
-  my $ShipTo = $doc->createElement("ShipTo");
-  $OpenShipment->appendChild($ShipTo);
+    my $ShipTo = $doc->createElement("ShipTo");
+    $OpenShipment->appendChild($ShipTo);
 
-  my $CompanyOrName = $doc->createElement("CompanyOrName");
-  $CompanyOrName->appendTextNode($name);
-  $ShipTo->appendChild($CompanyOrName);
-  my $Attention = $doc->createElement("Attention");
-  $Attention->appendTextNode($name);
-  $ShipTo->appendChild($Attention);
-  my $Address1 = $doc->createElement("Address1");
-  $Address1->appendTextNode($addr1);
-  $ShipTo->appendChild($Address1);
-  if ($addr2) {
-    my $Address2 = $doc->createElement("Address2");
-    $Address2->appendTextNode($addr2);
-    $ShipTo->appendChild($Address2);
-  }
-  my $CountryTerritory = $doc->createElement("CountryTerritory");
-  $CountryTerritory->appendTextNode($country);
-  $ShipTo->appendChild($CountryTerritory);
-  my $PostalCode = $doc->createElement("PostalCode");
-  $PostalCode->appendTextNode($postalcode);
-  $ShipTo->appendChild($PostalCode);
-  my $CityOrTown = $doc->createElement("CityOrTown");
-  $CityOrTown->appendTextNode($city);
-  $ShipTo->appendChild($CityOrTown);
-  my $StateProvinceCounty = $doc->createElement("StateProvinceCounty");
-  $StateProvinceCounty->appendTextNode($state);
-  $ShipTo->appendChild($StateProvinceCounty);
-  my $Telephone = $doc->createElement("Telephone");
-  $Telephone->appendTextNode($phone);
-  $ShipTo->appendChild($Telephone);
+    my $CompanyOrName = $doc->createElement("CompanyOrName");
+    $CompanyOrName->appendTextNode($name);
+    $ShipTo->appendChild($CompanyOrName);
+    my $Attention = $doc->createElement("Attention");
+    $Attention->appendTextNode($name);
+    $ShipTo->appendChild($Attention);
+    my $Address1 = $doc->createElement("Address1");
+    $Address1->appendTextNode($addr1);
+    $ShipTo->appendChild($Address1);
 
-  my $ShipmentInformation = $doc->createElement("ShipmentInformation");
-  $OpenShipment->appendChild($ShipmentInformation);
-  my $ServiceType = $doc->createElement("ServiceType");
-  $ServiceType->appendTextNode("MIP");
-  $ShipmentInformation->appendChild($ServiceType);
-  my $PackageType = $doc->createElement("PackageType");
-  $PackageType->appendTextNode("Parcels");
-  $ShipmentInformation->appendChild($PackageType);
-  my $NumberOfPackages = $doc->createElement("NumberOfPackages");
-  $NumberOfPackages->appendTextNode("1");
-  $ShipmentInformation->appendChild($NumberOfPackages);
-  my $ShipmentActualWeight = $doc->createElement("ShipmentActualWeight");
-  $ShipmentActualWeight->appendTextNode("0.1");
-  $ShipmentInformation->appendChild($ShipmentActualWeight);
-  my $DescriptionOfGoods = $doc->createElement("DescriptionOfGoods");
-  $DescriptionOfGoods->appendTextNode("Electronic Parts");
-  $ShipmentInformation->appendChild($DescriptionOfGoods);
-  my $Reference1 = $doc->createElement("Reference1");
-  $Reference1->appendTextNode($refnum);
-  $ShipmentInformation->appendChild($Reference1);
-  my $Reference2 = $doc->createElement("Reference2");
-  $Reference2->appendTextNode("KS");
-  $ShipmentInformation->appendChild($Reference2);
-  my $BillTransportationTo = $doc->createElement("BillTransportationTo");
-  $BillTransportationTo->appendTextNode("Shipper");
-  $ShipmentInformation->appendChild($BillTransportationTo);
-  my $BillDutyTaxTo = $doc->createElement("BillDutyTaxTo");
-  $BillDutyTaxTo->appendTextNode("Receiver");
-  $ShipmentInformation->appendChild($BillDutyTaxTo);
+    if ($addr2) {
+        my $Address2 = $doc->createElement("Address2");
+        $Address2->appendTextNode($addr2);
+        $ShipTo->appendChild($Address2);
+    }
+    my $CountryTerritory = $doc->createElement("CountryTerritory");
+    $CountryTerritory->appendTextNode($country);
+    $ShipTo->appendChild($CountryTerritory);
+    my $PostalCode = $doc->createElement("PostalCode");
+    $PostalCode->appendTextNode($postalcode);
+    $ShipTo->appendChild($PostalCode);
+    my $CityOrTown = $doc->createElement("CityOrTown");
+    $CityOrTown->appendTextNode($city);
+    $ShipTo->appendChild($CityOrTown);
+    my $StateProvinceCounty = $doc->createElement("StateProvinceCounty");
+    $StateProvinceCounty->appendTextNode($state);
+    $ShipTo->appendChild($StateProvinceCounty);
+    my $Telephone = $doc->createElement("Telephone");
+    $Telephone->appendTextNode($phone);
+    $ShipTo->appendChild($Telephone);
 
-  my $InternationalDocumentation = $doc->createElement("InternationalDocumentation");
-  $OpenShipment->appendChild($InternationalDocumentation);
-  my $CustomsValueTotal = $doc->createElement("CustomsValueTotal");
-  $CustomsValueTotal->appendTextNode(sprintf("%.2f", $total));
-  $InternationalDocumentation->appendChild($CustomsValueTotal);
-  my $CustomsValueCurrencyCode = $doc->createElement("CustomsValueCurrencyCode");
-  $CustomsValueCurrencyCode->appendTextNode("USD");
-  $InternationalDocumentation->appendChild($CustomsValueCurrencyCode);
-  my $InvoiceCurrencyCode = $doc->createElement("InvoiceCurrencyCode");
-  $InvoiceCurrencyCode->appendTextNode("US");
-  $InternationalDocumentation->appendChild($InvoiceCurrencyCode);
-  my $CN22GoodsType = $doc->createElement("CN22GoodsType");
-  $CN22GoodsType->appendTextNode("4");
-  $InternationalDocumentation->appendChild($CN22GoodsType);
-  my $CN22GoodsTypeOtherDescription = $doc->createElement("CN22GoodsTypeOtherDescription");
-  $CN22GoodsTypeOtherDescription->appendTextNode("Electronic Parts");
-  $InternationalDocumentation->appendChild($CN22GoodsTypeOtherDescription);
+    my $ShipmentInformation = $doc->createElement("ShipmentInformation");
+    $OpenShipment->appendChild($ShipmentInformation);
+    my $ServiceType = $doc->createElement("ServiceType");
+    $ServiceType->appendTextNode("MIP");
+    $ShipmentInformation->appendChild($ServiceType);
+    my $PackageType = $doc->createElement("PackageType");
+    $PackageType->appendTextNode("Parcels");
+    $ShipmentInformation->appendChild($PackageType);
+    my $NumberOfPackages = $doc->createElement("NumberOfPackages");
+    $NumberOfPackages->appendTextNode("1");
+    $ShipmentInformation->appendChild($NumberOfPackages);
+    my $ShipmentActualWeight = $doc->createElement("ShipmentActualWeight");
+    $ShipmentActualWeight->appendTextNode("0.1");
+    $ShipmentInformation->appendChild($ShipmentActualWeight);
+    my $DescriptionOfGoods = $doc->createElement("DescriptionOfGoods");
+    $DescriptionOfGoods->appendTextNode("Electronic Parts");
+    $ShipmentInformation->appendChild($DescriptionOfGoods);
+    my $Reference1 = $doc->createElement("Reference1");
+    $Reference1->appendTextNode($refnum);
+    $ShipmentInformation->appendChild($Reference1);
+    my $Reference2 = $doc->createElement("Reference2");
+    $Reference2->appendTextNode("KS");
+    $ShipmentInformation->appendChild($Reference2);
+    my $BillTransportationTo = $doc->createElement("BillTransportationTo");
+    $BillTransportationTo->appendTextNode("Shipper");
+    $ShipmentInformation->appendChild($BillTransportationTo);
+    my $BillDutyTaxTo = $doc->createElement("BillDutyTaxTo");
+    $BillDutyTaxTo->appendTextNode("Receiver");
+    $ShipmentInformation->appendChild($BillDutyTaxTo);
 
-  for my $item (@items) {
-    my $Goods = $doc->createElement("Goods");
-    $OpenShipment->appendChild($Goods);
-    my $PartNumber = $doc->createElement("PartNumber");
-    $PartNumber->appendTextNode($item->{name});
-    $Goods->appendChild($PartNumber);
-    my $DescriptionOfGood = $doc->createElement("DescriptionOfGood");
-    $DescriptionOfGood->appendTextNode("Electronic Part: " . $item->{name});
-    $Goods->appendChild($DescriptionOfGood);
-    my $TariffCode = $doc->createElement("Inv-NAFTA-TariffCode");
-    $TariffCode->appendTextNode("854231");
-    $Goods->appendChild($TariffCode);
-    my $Origin = $doc->createElement("Inv-NAFTA-CO-CountryTerritoryOfOrigin");
-    $Origin->appendTextNode("US");
-    $Goods->appendChild($Origin);
-    my $InvoiceUnits = $doc->createElement("InvoiceUnits");
-    $InvoiceUnits->appendTextNode($item->{qty});
-    $Goods->appendChild($InvoiceUnits);
-    my $InvoiceUnitOfMeasure = $doc->createElement("InvoiceUnitOfMeasure");
-    $InvoiceUnitOfMeasure->appendTextNode("EA");
-    $Goods->appendChild($InvoiceUnitOfMeasure);
-    my $UnitPrice = $doc->createElement("Invoice-SED-UnitPrice");
-    $UnitPrice->appendTextNode(sprintf("%.2f", $item->{price}));
-    $Goods->appendChild($UnitPrice);
+    my $InternationalDocumentation = $doc->createElement("InternationalDocumentation");
+    $OpenShipment->appendChild($InternationalDocumentation);
+    my $CustomsValueTotal = $doc->createElement("CustomsValueTotal");
+    $CustomsValueTotal->appendTextNode(sprintf("%.2f", $total));
+    $InternationalDocumentation->appendChild($CustomsValueTotal);
+    my $CustomsValueCurrencyCode = $doc->createElement("CustomsValueCurrencyCode");
+    $CustomsValueCurrencyCode->appendTextNode("USD");
+    $InternationalDocumentation->appendChild($CustomsValueCurrencyCode);
     my $InvoiceCurrencyCode = $doc->createElement("InvoiceCurrencyCode");
     $InvoiceCurrencyCode->appendTextNode("US");
-    $Goods->appendChild($InvoiceCurrencyCode);
-  }
-  my $filename = $refnum;
-  if ($specialchars > 1) {
-    $filename .= "_specialchars"
-  } elsif ($specialchars == 1) {
-    $filename .= "_latinchars"
-  }
-  if ($toolong) {
-    $filename .= "_long"
-  }
-  $doc->toFile($filename . ".xml", 2);
-  #print $doc->toString(2);
-  #exit;
+    $InternationalDocumentation->appendChild($InvoiceCurrencyCode);
+    my $CN22GoodsType = $doc->createElement("CN22GoodsType");
+    $CN22GoodsType->appendTextNode("4");
+    $InternationalDocumentation->appendChild($CN22GoodsType);
+    my $CN22GoodsTypeOtherDescription = $doc->createElement("CN22GoodsTypeOtherDescription");
+    $CN22GoodsTypeOtherDescription->appendTextNode("Electronic Parts");
+    $InternationalDocumentation->appendChild($CN22GoodsTypeOtherDescription);
+
+    for my $item (@items) {
+        my $Goods = $doc->createElement("Goods");
+        $OpenShipment->appendChild($Goods);
+        my $PartNumber = $doc->createElement("PartNumber");
+        $PartNumber->appendTextNode($item->{name});
+        $Goods->appendChild($PartNumber);
+        my $DescriptionOfGood = $doc->createElement("DescriptionOfGood");
+        $DescriptionOfGood->appendTextNode("Electronic Part: " . $item->{name});
+        $Goods->appendChild($DescriptionOfGood);
+        my $TariffCode = $doc->createElement("Inv-NAFTA-TariffCode");
+        $TariffCode->appendTextNode("854231");
+        $Goods->appendChild($TariffCode);
+        my $Origin = $doc->createElement("Inv-NAFTA-CO-CountryTerritoryOfOrigin");
+        $Origin->appendTextNode("US");
+        $Goods->appendChild($Origin);
+        my $InvoiceUnits = $doc->createElement("InvoiceUnits");
+        $InvoiceUnits->appendTextNode($item->{qty});
+        $Goods->appendChild($InvoiceUnits);
+        my $InvoiceUnitOfMeasure = $doc->createElement("InvoiceUnitOfMeasure");
+        $InvoiceUnitOfMeasure->appendTextNode("EA");
+        $Goods->appendChild($InvoiceUnitOfMeasure);
+        my $UnitPrice = $doc->createElement("Invoice-SED-UnitPrice");
+        $UnitPrice->appendTextNode(sprintf("%.2f", $item->{price}));
+        $Goods->appendChild($UnitPrice);
+        my $InvoiceCurrencyCode = $doc->createElement("InvoiceCurrencyCode");
+        $InvoiceCurrencyCode->appendTextNode("US");
+        $Goods->appendChild($InvoiceCurrencyCode);
+    }
+    my $filename = $refnum;
+    if ($specialchars > 1) {
+        $filename .= "_specialchars";
+    }
+    elsif ($specialchars == 1) {
+        $filename .= "_latinchars";
+    }
+    if ($toolong) {
+        $filename .= "_long";
+    }
+    $doc->toFile($filename . ".xml", 2);
+    #print $doc->toString(2);
+    #exit;
 }

--- a/tracking.pl
+++ b/tracking.pl
@@ -1,39 +1,39 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # run this on the .Out files written by UPS Worldship
 # it prints a nice list which allows for easily marking
 # the rewards as shipped, with the tracking number.
 
-foreach $file (@ARGV) {
-	#print "File $file\n";
-	open $fh, "<", $file or die "$!";
-	undef $reference;
-	undef $tracking;
-	undef $name;
-	while (<$fh>) {
-		if (/<Reference1>([A-Z][0-9]{4})<\/Reference1>/) {
-			$reference = $1;
-			#print "ref: $reference\n";
-		}
-		if (/<CompanyOrName>([^<]+)<\/CompanyOrName>/) {
-			$name = $1;
-			#print "name: $name\n";
-		}
-		if (/<MailManifestId>([0-9]+)<\/MailManifestId>/) {
-			$tracking = $1;
-			#print "track: $tracking\n";
-		}
-	}
-	close $fh;
-	if ($reference && $tracking && $name) {
-		print $reference, "  ", $tracking, "  ", $name, "\n";
-	}
+use strict;
+
+for my $file (@ARGV) {
+    #print "File $file\n";
+    open(my $fh, "<", $file) or die "$!";
+    my ($reference, $tracking, $name);
+
+    while (<$fh>) {
+        if (/<Reference1>([A-Z][0-9]{4})<\/Reference1>/) {
+            $reference = $1;
+            #print "ref: $reference\n";
+        }
+        if (/<CompanyOrName>([^<]+)<\/CompanyOrName>/) {
+            $name = $1;
+            #print "name: $name\n";
+        }
+        if (/<MailManifestId>([0-9]+)<\/MailManifestId>/) {
+            $tracking = $1;
+            #print "track: $tracking\n";
+        }
+    }
+
+    if ($reference && $tracking && $name) {
+        print $reference, "  ", $tracking, "  ", $name, "\n";
+    }
 }
 
-foreach $country (sort keys(%list)) {
-	printf " %4d: ", $list{$country};
-	print "$country\n";
-
+for my $country (sort keys(%list)) {
+    printf " %4d: ", $list{$country};
+    print "$country\n";
 
 }
 


### PR DESCRIPTION
Make everything work under "use strict", including proper use of lexical file handles so they'll get automatically closed when no longer available.  Prevents use of variables that are not in scope making several cases to not be needed.

Unfortunately it doesn't help with the special character cases as from what I can tell it's improperly encoded data from kickstarter, and while it might be possible to fix it, it'll need to be done on a case by case basis (yuck).

That said this should help people who want to use this stuff in the future and make small modifications for their own kickstarters.

I also changed all the shebang lines to use /usr/bin/env perl, so they'll work properly with perlbrew installed perl's and other perls that are installed in non-system directories, while still functioning properly in every other case (windows, etc.)
